### PR TITLE
Issue 26 | Fix: bind server to 0.0.0.0 and require host in Config

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -4,6 +4,7 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 export const PORT = Number(process.env.PORT) || 3000;
+export const HOST = process.env.HOST || '0.0.0.0';
 export const JWT_SECRET = process.env.JWT_SECRET || '';
 export const ADMIN_USERNAME = process.env.ADMIN_USERNAME || 'admin';
 export const ADMIN_PASSWORD_HASH = process.env.ADMIN_PASSWORD_HASH || '';
@@ -15,6 +16,7 @@ export const FILES_DIR = process.env.FILES_DIR || '/path/to/mounted/proxmox/stor
  */
 export interface Config {
     port: number;
+    host: string;
     jwtSecret: string;
     adminUser: string;
     adminPasswordHash: string;
@@ -23,6 +25,7 @@ export interface Config {
 
 export const config: Config = {
     port: PORT,
+    host: HOST,
     jwtSecret: JWT_SECRET,
     adminUser: ADMIN_USERNAME,
     adminPasswordHash: ADMIN_PASSWORD_HASH,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -26,9 +26,8 @@ app.get('/', (req, res) => {
 app.use((_req, _res, next) => next(new NotFoundError('Route not found')));
 
 // Start the server
-const server = app.listen(config.port, () => {
-    // eslint-disable-next-line no-console
-    console.log(`Server listening on port ${config.port} — http://localhost:${config.port}/`);
+const server = app.listen(config.port, config.host, () => {
+    console.log(`Server listening on ${config.host}:${config.port} — http://${config.host}:${config.port}/`);
 });
 
 // Register the global error handler *after* all routes and middleware


### PR DESCRIPTION
This pull request introduces support for configuring the server's listening host via environment variables, in addition to the port. This makes the backend more flexible for deployment in different environments. The changes update both the configuration logic and the server startup code to use the new `host` setting.

Configuration enhancements:

* Added `HOST` environment variable support in `backend/src/config/env.ts`, defaulting to `'0.0.0.0'` if not set.
* Updated the `Config` interface and the exported `config` object to include the new `host` property. [[1]](diffhunk://#diff-5caf8928ff8ccfe66b8468738b640e64608b96521121a3c681a1738d8cabc336R19) [[2]](diffhunk://#diff-5caf8928ff8ccfe66b8468738b640e64608b96521121a3c681a1738d8cabc336R28)

Server startup updates:

* Modified the server initialization in `backend/src/index.ts` to use both `config.port` and `config.host`, and updated the startup log message to reflect the host and port.

Closes #26 