### PR TITLE
Fix: email -> username

### DIFF
--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -1,4 +1,4 @@
-import { Lock, Mail } from "lucide-react";
+import { Lock, User } from "lucide-react";
 import { motion } from "motion/react";
 import { Button } from "../../../components/Button";
 import { TextInput } from "../../../components/TextInput";
@@ -7,14 +7,10 @@ import type { LoginFormProps } from "../types/auth.types";
 
 /**
  * LoginForm Component
- * Displays a login form with email/password inputs and validation
+ * Displays a login form with username/password inputs and validation
  * Uses custom hook for form state management and validation logic
  */
-export const LoginForm = ({
-  onSubmit,
-  onForgotPassword,
-  isLoading = false,
-}: LoginFormProps) => {
+export const LoginForm = ({ onSubmit, isLoading = false }: LoginFormProps) => {
   // Use custom hook for form logic
   const { formData, errors, touched, updateField, handleBlur, validateForm } =
     useLoginForm();
@@ -28,7 +24,7 @@ export const LoginForm = ({
 
     // Validate and submit if valid
     if (validateForm()) {
-      onSubmit?.(formData.email, formData.password);
+      onSubmit?.(formData.username, formData.password);
     }
   };
 
@@ -45,19 +41,19 @@ export const LoginForm = ({
 
         {/* Login form */}
         <form onSubmit={handleSubmit} className="space-y-4">
-          {/* Email input field */}
+          {/* Username input field */}
           <TextInput
-            label="Email"
-            type="email"
-            placeholder="you@example.com"
-            value={formData.email}
-            onChange={(e) => updateField("email", e.target.value)}
-            onBlur={() => handleBlur("email")}
-            error={touched.email ? errors.email : ""}
+            label="Username"
+            type="text"
+            placeholder="your-username"
+            value={formData.username}
+            onChange={(e) => updateField("username", e.target.value)}
+            onBlur={() => handleBlur("username")}
+            error={touched.username ? errors.username : ""}
             disabled={isLoading}
             required
             fullWidth
-            icon={<Mail className="w-5 h-5" />}
+            icon={<User className="w-5 h-5" />}
           />
 
           {/* Password input field */}
@@ -86,17 +82,7 @@ export const LoginForm = ({
             {isLoading ? "Logging in..." : "Log In"}
           </Button>
 
-          {/* Forgot password link */}
-          <Button
-            type="button"
-            variant="ghost"
-            size="md"
-            fullWidth
-            onClick={onForgotPassword}
-            disabled={isLoading}
-          >
-            Forgot Password?
-          </Button>
+          {/* No forgot password button - handled elsewhere if needed */}
         </form>
       </div>
     </motion.div>

--- a/frontend/src/features/auth/hooks/useLoginForm.ts
+++ b/frontend/src/features/auth/hooks/useLoginForm.ts
@@ -4,7 +4,7 @@ import type {
     LoginFormErrors,
     LoginFormTouched,
 } from "../types/auth.types";
-import { validateEmail, validatePassword } from "../utils/validation";
+import { validateUsername, validatePassword } from "../utils/validation";
 
 /**
  * Custom hook for managing login form state and validation
@@ -13,19 +13,19 @@ import { validateEmail, validatePassword } from "../utils/validation";
 export const useLoginForm = () => {
     // Form state management
     const [formData, setFormData] = useState<LoginFormData>({
-        email: "",
+        username: "",
         password: "",
     });
 
     // Error state for validation feedback
     const [errors, setErrors] = useState<LoginFormErrors>({
-        email: "",
+        username: "",
         password: "",
     });
 
     // Track if user has attempted to interact with fields
     const [touched, setTouched] = useState<LoginFormTouched>({
-        email: false,
+        username: false,
         password: false,
     });
 
@@ -43,8 +43,8 @@ export const useLoginForm = () => {
         setTouched((prev) => ({ ...prev, [field]: true }));
 
         // Validate on blur
-        if (field === "email") {
-            setErrors((prev) => ({ ...prev, email: validateEmail(formData.email) }));
+        if (field === "username") {
+            setErrors((prev) => ({ ...prev, username: validateUsername(formData.username) }));
         } else {
             setErrors((prev) => ({
                 ...prev,
@@ -58,27 +58,27 @@ export const useLoginForm = () => {
      * @returns true if form is valid, false otherwise
      */
     const validateForm = (): boolean => {
-        const emailError = validateEmail(formData.email);
+        const usernameError = validateUsername(formData.username);
         const passwordError = validatePassword(formData.password);
 
         setErrors({
-            email: emailError,
+            username: usernameError,
             password: passwordError,
         });
 
         // Mark all fields as touched
-        setTouched({ email: true, password: true });
+        setTouched({ username: true, password: true });
 
-        return !emailError && !passwordError;
+        return !usernameError && !passwordError;
     };
 
     /**
      * Resets form to initial state
      */
     const resetForm = () => {
-        setFormData({ email: "", password: "" });
-        setErrors({ email: "", password: "" });
-        setTouched({ email: false, password: false });
+        setFormData({ username: "", password: "" });
+        setErrors({ username: "", password: "" });
+        setTouched({ username: false, password: false });
     };
 
     return {

--- a/frontend/src/features/auth/types/auth.types.ts
+++ b/frontend/src/features/auth/types/auth.types.ts
@@ -1,21 +1,20 @@
 // Login form types
 export interface LoginFormData {
-    email: string;
+    username: string;
     password: string;
 }
 
 export interface LoginFormErrors {
-    email: string;
+    username: string;
     password: string;
 }
 
 export interface LoginFormTouched {
-    email: boolean;
+    username: boolean;
     password: boolean;
 }
 
 export interface LoginFormProps {
-    onSubmit?: (email: string, password: string) => void;
-    onForgotPassword?: () => void;
+    onSubmit?: (username: string, password: string) => void;
     isLoading?: boolean;
 }

--- a/frontend/src/features/auth/utils/validation.ts
+++ b/frontend/src/features/auth/utils/validation.ts
@@ -1,25 +1,19 @@
 /**
- * Validates email format using regex pattern
- * @param email - Email string to validate
+ * Validates username presence
+ * @param username - Username string to validate
  * @returns Error message if invalid, empty string if valid
  */
-export const validateEmail = (email: string): string => {
-    if (!email) return "Email is required";
-    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-        return "Please enter a valid email address";
-    }
+export const validateUsername = (username: string): string => {
+    if (!username) return "Username is required";
     return "";
 };
 
 /**
- * Validates password length requirement
+ * Validates password presence (no length restrictions)
  * @param password - Password string to validate
  * @returns Error message if invalid, empty string if valid
  */
 export const validatePassword = (password: string): string => {
     if (!password) return "Password is required";
-    if (password.length < 6) {
-        return "Password must be at least 6 characters";
-    }
     return "";
 };

--- a/frontend/src/pages/Auth.tsx
+++ b/frontend/src/pages/Auth.tsx
@@ -2,31 +2,15 @@ import { motion } from "motion/react";
 import { LoginForm } from "../features/auth/components/LoginForm";
 import BoxmoxLogo from "../assets/boxmox.svg";
 
-/**
- * Auth Page
- * Displays the login form with a clean, minimal layout
- * Features a centered design with subtle background elements
- */
 export const AuthPage = () => {
-  /**
-   * Handles successful login submission
-   * In production, this would call the auth service
-   */
-  const handleLogin = (email: string, password: string) => {
-    console.log("Login attempt:", { email, password });
+  // Login handler — uses username and password
+  const handleLogin = (username: string, password: string) => {
+    console.log("Login attempt:", { username, password });
     // TODO: Implement actual authentication logic
-    alert(`Login attempt with email: ${email}`);
+    alert(`Login attempt with username: ${username}`);
   };
 
-  /**
-   * Handles forgot password flow
-   * In production, this would navigate to password reset
-   */
-  const handleForgotPassword = () => {
-    console.log("Forgot password clicked");
-    // TODO: Implement forgot password flow
-    alert("Forgot password functionality coming soon!");
-  };
+  // Forgot password handler removed; this flow is not in the UI
 
   return (
     <div className="min-h-screen bg-[#0D1117] flex items-center justify-center p-4">
@@ -84,10 +68,7 @@ export const AuthPage = () => {
         </motion.div>
 
         {/* Login form component */}
-        <LoginForm
-          onSubmit={handleLogin}
-          onForgotPassword={handleForgotPassword}
-        />
+        <LoginForm onSubmit={handleLogin} />
       </div>
     </div>
   );


### PR DESCRIPTION
This pull request updates the login flow to use a username and password instead of an email and password. It removes all references to email from the login form, validation, and types, and simplifies the password validation logic. The "Forgot Password" button and related logic have also been removed from the UI and codebase.

**Login form and validation changes:**

* The login form now asks for a `username` instead of an `email`, updates all field labels, placeholders, and icons accordingly, and removes the "Forgot Password" button. (`LoginForm.tsx` [[1]](diffhunk://#diff-46ef07869b12b21c39a6897a0558488d681798c0d0667d6cddea34981ec6c71eL1-R1) [[2]](diffhunk://#diff-46ef07869b12b21c39a6897a0558488d681798c0d0667d6cddea34981ec6c71eL10-R13) [[3]](diffhunk://#diff-46ef07869b12b21c39a6897a0558488d681798c0d0667d6cddea34981ec6c71eL31-R27) [[4]](diffhunk://#diff-46ef07869b12b21c39a6897a0558488d681798c0d0667d6cddea34981ec6c71eL48-R56) [[5]](diffhunk://#diff-46ef07869b12b21c39a6897a0558488d681798c0d0667d6cddea34981ec6c71eL89-R85)
* The custom login form hook and types now use `username` instead of `email` for form state, errors, and touched tracking. (`useLoginForm.ts` [[1]](diffhunk://#diff-6651e3016d61ca933aa00c3890788505adac50c044a8b42c7dd6bc9270ec989fL7-R7) [[2]](diffhunk://#diff-6651e3016d61ca933aa00c3890788505adac50c044a8b42c7dd6bc9270ec989fL16-R28) [[3]](diffhunk://#diff-6651e3016d61ca933aa00c3890788505adac50c044a8b42c7dd6bc9270ec989fL46-R47) [[4]](diffhunk://#diff-6651e3016d61ca933aa00c3890788505adac50c044a8b42c7dd6bc9270ec989fL61-R81); `auth.types.ts` [[5]](diffhunk://#diff-a027a7181210abcfd14b48f4169b7624691ededae09d73b3e827149eb8a1d112L3-R18)
* Validation logic has been updated to check for username presence instead of email format, and password validation now only checks for presence (no length requirement). (`validation.ts` [frontend/src/features/auth/utils/validation.tsL2-L23](diffhunk://#diff-d1d85e7eb457721a31cac83f244820df6c7a8f03cc8cbfabaa424c57097cbf3aL2-L23))

**Auth page integration:**

* The `AuthPage` component and its login handler now expect a `username` and `password` instead of `email` and `password`. All references to forgot password functionality have been removed. (`Auth.tsx` [[1]](diffhunk://#diff-1ab3cb1e8e302873807ae387fa92a58fa733f8f2fef8bcc105aa3e82535aeb67L5-R13) [[2]](diffhunk://#diff-1ab3cb1e8e302873807ae387fa92a58fa733f8f2fef8bcc105aa3e82535aeb67L87-R71)