### PR TITLE
Fix: Added dupe folder error

### DIFF
--- a/backend/src/controllers/folderController.ts
+++ b/backend/src/controllers/folderController.ts
@@ -28,6 +28,15 @@ export async function createFolder(req: Request, res: Response) {
         throw new ValidationError('Invalid folder path');
     }
 
+
+    // Check if folder already exists before creating
+    const fs = require('fs');
+    const absPath = require('../utils/pathSanitizer').resolveSecurePath(require('../config/env').FILES_DIR, folderPath);
+    if (fs.existsSync(absPath)) {
+        // Throw a validation error with a clear message for the frontend
+        throw new ValidationError('A folder with that name already exists in this location.');
+    }
+
     await fileStorage.ensureDirectory(folderPath);
 
     info('Folder created', { folder: folderPath });


### PR DESCRIPTION
This pull request improves the folder creation logic in the backend by adding a check to prevent creating a folder if one with the same name already exists in the specified location. This helps prevent accidental overwrites and provides a clearer error message for the frontend.

Validation and error handling improvements:

* Added a check in `createFolder` (in `folderController.ts`) to verify if a folder already exists at the target path before attempting to create it, and throws a `ValidationError` with a clear message if it does.