### PR TITLE
Improved logger time stamp format

### DIFF
--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -10,7 +10,17 @@ import { Request, Response, NextFunction } from 'express';
 
 /** Format a timestamped message. Internal helper. */
 function formatMessage(level: string, message: string) {
-    return `[${level}] ${new Date().toISOString()} - ${message}`;
+    const now = new Date();
+    const timestamp = now.toLocaleString('en-US', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: true
+    });
+    return `[${level}] ${timestamp} - ${message}`;
 }
 
 /** Log a simple info message with optional metadata. */


### PR DESCRIPTION
This pull request updates the timestamp formatting in log messages to use a more readable, locale-specific format. The change affects how log entries are displayed, making them easier to interpret at a glance.

Logging improvements:

* Updated the `formatMessage` helper in `backend/src/utils/logger.ts` to use `toLocaleString` for timestamps, providing a formatted date and time in 'en-US' locale with 12-hour time.

Closes #86 