### PR TITLE
Fix: move files locally

### DIFF
--- a/backend/src/utils/fileStorage.ts
+++ b/backend/src/utils/fileStorage.ts
@@ -115,6 +115,34 @@ export async function deleteFile(storagePath: string): Promise<void> {
 }
 
 /**
+ * Rename (move) a file within FILES_DIR.
+ *
+ * @param oldPath - Current relative file path
+ * @param newPath - New relative file path
+ * @throws {FileNotFoundError} If old file does not exist
+ * @throws {FileStorageError} If rename fails
+ */
+export async function renameFile(oldPath: string, newPath: string): Promise<void> {
+    const oldAbs = resolveSecurePath(FILES_DIR, oldPath);
+    const newAbs = resolveSecurePath(FILES_DIR, newPath);
+
+    try {
+        await fs.access(oldAbs);
+    } catch {
+        throw new FileNotFoundError(`File not found: ${oldPath}`);
+    }
+
+    try {
+        await fs.rename(oldAbs, newAbs);
+    } catch (err) {
+        logger.error(`Failed to rename file: ${oldPath} -> ${newPath}`, err);
+        throw new FileStorageError(
+            `Failed to rename file: ${err instanceof Error ? err.message : 'Unknown error'}`
+        );
+    }
+}
+
+/**
  * Rename (move) a folder within FILES_DIR.
  *
  * @param oldPath - Current relative folder path
@@ -249,6 +277,7 @@ export default {
     ensureDirectory,
     listFiles,
     deleteFile,
+    renameFile,
     renameFolder,
     deleteFolder,
     listDirectoryContents,


### PR DESCRIPTION
This pull request enhances the file move functionality by ensuring that the underlying physical file is atomically moved on disk when a file is moved or replaced, not just its metadata. The changes introduce a new utility function for renaming (moving) files within the storage directory and update the move logic to use this function, improving data consistency and error handling during file operations.

**File Move and Replacement Improvements:**

* When a file is moved or replaced, the physical file is now atomically moved on disk using the new `renameFile` utility, ensuring the storage reflects metadata changes and preventing inconsistencies. (`move.ts`, `fileStorage.ts`) [[1]](diffhunk://#diff-83271f1d04913090ffd8acf48c555ccd4810f4797122e8be931d95bfff160f81R85-R90) [[2]](diffhunk://#diff-83271f1d04913090ffd8acf48c555ccd4810f4797122e8be931d95bfff160f81R113-R118)

**File Storage Utility Enhancements:**

* Added a new `renameFile` function to `fileStorage.ts` that securely renames (moves) a file within the storage directory, with proper error handling for missing files and failed operations. (`fileStorage.ts`)
* Exported the new `renameFile` function from `fileStorage.ts` for use elsewhere in the codebase. (`fileStorage.ts`)

**Dependency Updates:**

* Imported the new `fileStorage` utility in the file move controller to support the updated move logic. (`move.ts`)